### PR TITLE
Added External ID to AdvancedMatching interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ export interface AdvancedMatching {
   ph: string;
   st: string;
   zp: string;
+  external_id: string;
 }
 
 export interface Data {}


### PR DESCRIPTION
Added `external_id` based on [the documentation](https://developers.facebook.com/docs/meta-pixel/advanced/advanced-matching).