### PR TITLE
Make AdvancedMatching types optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,17 +4,17 @@ export interface Options {
 }
 
 export interface AdvancedMatching {
-  ct: string;
-  country: string;
-  db: string;
-  em: string;
-  fn: string;
-  ge: string;
-  ln: string;
-  ph: string;
-  st: string;
-  zp: string;
-  external_id: string;
+  ct?: string;
+  country?: string;
+  db?: string;
+  em?: string;
+  fn?: string;
+  ge?: string;
+  ln?: string;
+  ph?: string;
+  st?: string;
+  zp?: string;
+  external_id?: string;
 }
 
 export interface Data {}


### PR DESCRIPTION
It would be great if you updated the README to point to the correct `bettercart/`prefix and released the latest version to npm as well :)